### PR TITLE
fix(local-setup): add FLW product to automation manifest

### DIFF
--- a/amrit-local-setup/automation/lib/products.conf
+++ b/amrit-local-setup/automation/lib/products.conf
@@ -11,6 +11,7 @@
 #   TM      → scheduler + identity URLs
 #   HL104   → common endpoints only
 #   HL1097  → fhir + beneficiary + ecd KM + identity + common
+#   FLW     → common_example.properties: tm-url + fhir-url            → Common + Identity + BeneficiaryID + FLW + TM + Scheduler + FHIR
 
 declare -A PRODUCT_APIS=(
   [admin]="Common-API Identity-API BeneficiaryID-Generation-API Admin-API"
@@ -20,6 +21,7 @@ declare -A PRODUCT_APIS=(
   [tm]="Common-API Identity-API BeneficiaryID-Generation-API TM-API Scheduler-API"
   [hl104]="Common-API Identity-API BeneficiaryID-Generation-API Helpline104-API"
   [hl1097]="Common-API Identity-API BeneficiaryID-Generation-API Helpline1097-API"
+  [flw]="Common-API Identity-API BeneficiaryID-Generation-API FLW-API TM-API Scheduler-API FHIR-API"
 )
 
 declare -A PRODUCT_UIS=(
@@ -30,6 +32,7 @@ declare -A PRODUCT_UIS=(
   [tm]="TM-UI"
   [hl104]="Helpline104-UI"
   [hl1097]="Helpline1097-UI"
+  [flw]=""
 )
 
 declare -A PRODUCT_DESC=(
@@ -40,7 +43,8 @@ declare -A PRODUCT_DESC=(
   [tm]="Telemedicine"
   [hl104]="Helpline 104"
   [hl1097]="Helpline 1097"
+  [flw]="Front Line Workers"
 )
 
 # Canonical iteration order for menus. Admin first so newcomers see it.
-PRODUCT_ORDER=(admin ecd hwc mmu tm hl104 hl1097)
+PRODUCT_ORDER=(admin ecd hwc mmu tm hl104 hl1097 flw)

--- a/amrit-local-setup/automation/lib/products.conf
+++ b/amrit-local-setup/automation/lib/products.conf
@@ -33,7 +33,6 @@ declare -A PRODUCT_UIS=(
   [tm]="TM-UI"
   [hl104]="Helpline104-UI"
   [hl1097]="Helpline1097-UI"
-  [flw]=""  # API-only, no UI launcher
 )
 
 declare -A PRODUCT_DESC=(

--- a/amrit-local-setup/automation/lib/products.conf
+++ b/amrit-local-setup/automation/lib/products.conf
@@ -11,7 +11,8 @@
 #   TM      → scheduler + identity URLs
 #   HL104   → common endpoints only
 #   HL1097  → fhir + beneficiary + ecd KM + identity + common
-#   FLW     → common_example.properties: tm-url + fhir-url            → Common + Identity + BeneficiaryID + FLW + TM + Scheduler + FHIR
+#   FLW     → common_example.properties: tm-url + fhir-url            → Common + Identity + BeneficiaryID + FLW + TM + FHIR
+#             (Scheduler-API added transitively because TM-API requires scheduler-url)
 
 declare -A PRODUCT_APIS=(
   [admin]="Common-API Identity-API BeneficiaryID-Generation-API Admin-API"
@@ -32,7 +33,7 @@ declare -A PRODUCT_UIS=(
   [tm]="TM-UI"
   [hl104]="Helpline104-UI"
   [hl1097]="Helpline1097-UI"
-  [flw]=""
+  [flw]=""  # API-only, no UI launcher
 )
 
 declare -A PRODUCT_DESC=(


### PR DESCRIPTION
## 📋 Description

JIRA ID: N/A

FLW-API was already registered in lib/services.conf with its repo URL, 
port (8081), and properties file, but there was no [flw] entry in 
lib/products.conf. This meant running bash start.sh --product=flw 
didn't work for anyone trying to set up the FLW module locally.

Added flw to PRODUCT_APIS, PRODUCT_UIS, PRODUCT_DESC, and PRODUCT_ORDER. 
Dependencies were sourced from FLW-API's common_example.properties which 
references tm-url and fhir-url.

Closes PSMRI/AMRIT#140

---

## ✅ Type of Change

- [x] 🐞 Bug fix (non-breaking change which resolves an issue)

---

## ℹ️ Additional Information

Verified the dependency chain by checking 
FLW-API/src/main/environment/common_example.properties directly.
No existing tests are affected by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Front Line Workers product, including UI/description entry, menu placement, and integration with required backend services (identity, beneficiary ID generation, FLW API, scheduling, TM and FHIR).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->